### PR TITLE
開発環境整備: CPackまわり / 開発環境リソースディレクトリ

### DIFF
--- a/.github/workflows/build_m1_mac.yml
+++ b/.github/workflows/build_m1_mac.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           name: ikulab-motion-viewer-m1-macos
           path: |
-            ./build/ikulab-motion-viewer-1.2.0-Darwin.dmg
+            ./build_release/ikulab-motion-viewer-1.2.0-Darwin.dmg

--- a/.github/workflows/build_m1_mac.yml
+++ b/.github/workflows/build_m1_mac.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           name: ikulab-motion-viewer-m1-macos
           path: |
-            ./build_release/ikulab-motion-viewer-1.2.0-Darwin.dmg
+            ./build_release/*.dmg

--- a/.github/workflows/build_m1_mac.yml
+++ b/.github/workflows/build_m1_mac.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           name: ikulab-motion-viewer-m1-macos
           path: |
-            ./build/ikulab-motion-viewer-0.1.0-Darwin.dmg
+            ./build/ikulab-motion-viewer-1.2.0-Darwin.dmg

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build
+build_debug
+build_release
 vcpkg_installed
 .ccls-cache
 imgui.ini

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,16 @@ target_link_libraries(ikulab-motion-viewer PRIVATE tinyfiledialogs::tinyfiledial
 target_link_libraries(ikulab-motion-viewer PRIVATE glm::glm)
 
 # ------------------------------------------------------------
+# config ikulab-motion-viewer 
+# ------------------------------------------------------------
+
+# override application resource director
+if (DEFINED RESOURCE_DIR)
+    target_compile_definitions(ikulab-motion-viewer PRIVATE RESOURCE_DIR="${RESOURCE_DIR}")
+    message(STATUS "Resource directory is set to ${RESOURCE_DIR}")
+endif ()
+
+# ------------------------------------------------------------
 # Config installer
 # ------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,10 @@ target_link_libraries(ikulab-motion-viewer PRIVATE glm::glm)
 # Config installer
 # ------------------------------------------------------------
 
-include(CPack)
-
 # prepare MacOS bundle
-if (APPLE)
+if (APPLE AND GENERATE_PACKAGE)
+    include(CPack)
+
     # create bundle (and install binary and Info.plist)
     set_target_properties(ikulab-motion-viewer PROPERTIES
         MACOSX_BUNDLE TRUE
@@ -95,20 +95,24 @@ if (APPLE)
     # fonts
     install(DIRECTORY ${PROJECT_SOURCE_DIR}/assets/fonts
         DESTINATION ikulab-motion-viewer.app/Contents/Resources)
+
+    # CPack config for MacOS
+    set(CPACK_BUNDLE_NAME "ikulab-motion-viewer")
+    set(CPACK_BUNDLE_PLIST "${PROJECT_SOURCE_DIR}/Info.plist")
+    set(CPACK_BUNDLE_ICON "${PROJECT_SOURCE_DIR}/icon.icns")
+    set(CPACK_BUNDLE_STARTUP_COMMAND "${PROJECT_SOURCE_DIR}/build/app/startup.sh")
 endif ()
 
+if (LINUX AND GENERATE_PACKAGE)
+    # CPack config
+    set(CPACK_GENERATOR DEB)
+    set(CPACK_PACKAGE_VENDOR "ikulab / CaffeineFree")
+    set(CPACK_PACKAGE_NAME "ikulab-motion-viewer")
+    set(CPACK_PACKAGE_CONTACT "dev@caffeinezero.info")
+    set(CPACK_PACKAGE_DESCRIPTION "The BVH Motion Viewer powered by ikura Graphics Engine.")
+    set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE.txt")
+endif ()
 
-# CPack config
-set(CPACK_GENERATOR DEB)
-set(CPACK_PACKAGE_VENDOR "ikulab / CaffeineFree")
-set(CPACK_PACKAGE_NAME "ikulab-motion-viewer")
-set(CPACK_PACKAGE_CONTACT "dev@caffeinezero.info")
-set(CPACK_PACKAGE_DESCRIPTION "The BVH Motion Viewer powered by ikura Graphics Engine.")
-set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE.txt")
-
-# CPack config for MacOS
-set(CPACK_BUNDLE_NAME "ikulab-motion-viewer")
-set(CPACK_BUNDLE_PLIST "${PROJECT_SOURCE_DIR}/Info.plist")
-set(CPACK_BUNDLE_ICON "${PROJECT_SOURCE_DIR}/icon.icns")
-set(CPACK_BUNDLE_STARTUP_COMMAND "${PROJECT_SOURCE_DIR}/build/app/startup.sh")
-
+if (WIN32 AND GENERATE_PACKAGE)
+    # todo
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif ()
 # ------------------------------------------------------------
 
 # set IMV_IS_DEBUG flag
-if ("${BUILD_TYPE}" STREQUAL "Debug")
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     add_compile_options(-DIMV_IS_DEBUG)
 endif ()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,12 +2,30 @@
   "version": 2,
   "configurePresets": [
     {
-      "name": "default",
+      "name": "base",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+      }
+    },
+    {
+      "name": "develop",
+      "inherits": "base",
+      "binaryDir": "${sourceDir}/build_debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "RESOURCE_DIR": "${sourceDir}/assets"
+      }
+    },
+    {
+      "name": "release",
+      "inherits": "base",
+      "binaryDir": "${sourceDir}/build_release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "GENERATE_PACKAGE": "ON"
       }
     }
   ]

--- a/app/resourceDirectory.cpp
+++ b/app/resourceDirectory.cpp
@@ -7,17 +7,30 @@
 
 #include <tinyfiledialogs.h>
 
+// ------------------------------------------------------------
+// getResourceDirectory
+// ------------------------------------------------------------
+
+#ifdef RESOURCE_DIR
+
+std::filesystem::path getResourceDirectory() {
+    std::filesystem::path resourceDir = RESOURCE_DIR;
+
+    return resourceDir;
+}
+
+#else
+
 #ifdef __linux__
+
 std::filesystem::path getResourceDirectory() {
     std::filesystem::path resourceDir = "/usr/local/share/ikulab-motion-viewer";
 
     return resourceDir;
 }
 
-std::filesystem::path getHomeDirectory() { return getenv("HOME"); }
-#endif
+#elif __APPLE__
 
-#ifdef __APPLE__
 /**
  * @brief Check if the application is launched from a bundle.
  * i.e. if the application launched by double-clicking .app file from Finder.
@@ -64,10 +77,8 @@ std::filesystem::path getResourceDirectory() {
     }
 }
 
-std::filesystem::path getHomeDirectory() { return getenv("HOME"); }
-#endif
+#elif IS_WINDOWS
 
-#ifdef IS_WINDOWS
 std::filesystem::path getResourceDirectory() {
     std::filesystem::path homeDrive = getenv("HOMEDRIVE");
     std::filesystem::path homePath = getenv("HOMEPATH");
@@ -75,6 +86,24 @@ std::filesystem::path getResourceDirectory() {
 
     return resourceDir;
 }
+
+#endif
+
+#endif
+
+// ------------------------------------------------------------
+// getHomeDirectory
+// ------------------------------------------------------------
+
+#ifdef __linux__
+
+std::filesystem::path getHomeDirectory() { return getenv("HOME"); }
+
+#elif __APPLE__
+
+std::filesystem::path getHomeDirectory() { return getenv("HOME"); }
+
+#elif IS_WINDOWS
 
 std::filesystem::path getHomeDirectory() {
 

--- a/utils/scripts/build_app_package.sh
+++ b/utils/scripts/build_app_package.sh
@@ -16,10 +16,10 @@ cd "$project_dir" || exit
 
 green "Building binary..."
 
-cmake --preset=default
-cmake --build build
+cmake --preset=release
+cmake --build build_release
 
-cd build
+cd build_release
 
 green "Generating package..."
 


### PR DESCRIPTION
- CPackまわりの設定を整理した
    - プラットフォームごとにifブロックでまとめた
- CMakePresetを増やして、`develop` の場合はリポジトリのassetsをリソースディレクトリとして使うようにした
- `BUILD_TYPE` の使用をやめ、CMakeで用意されている `CMAKE_BUILD_TYPE` を使うようにした