### PR TITLE
MacOS版のアニメーションウィンドウの初期位置のズレを修正

### DIFF
--- a/app/updateUi.cpp
+++ b/app/updateUi.cpp
@@ -180,8 +180,11 @@ void initAnimationControlWindowSize(
     const float nativeWindowHeightScaled =
         static_cast<float>(mainWindow->getHeight()) / mainWindow->getScaleY();
 
+    // アニメーションウィンドウの初期位置を計算
+    // 横方向は中央揃え
     const auto posX =
         (nativeWindowWidthScaled - static_cast<float>(animWindowWidth)) / 2;
+    // 縦方向は下揃えで、OSウィンドウの下端からマージンを開ける
     const auto posY = nativeWindowHeightScaled -
                       static_cast<float>(animWindowHeight) -
                       ANIM_WINDOW_BOTTOM_MARGIN;

--- a/app/updateUi.cpp
+++ b/app/updateUi.cpp
@@ -7,10 +7,12 @@
 
 #include "./motionUtil/bvhExporter.hpp"
 
-#define MAIN_CONTROL_BUTTON_SIZE_UNIT 40
+namespace {
+constexpr int MAIN_CONTROL_BUTTON_SIZE_UNIT = 40;
 
-#define ANIM_WINDOW_HEIGHT_NORMAL 250
-#define ANIM_WINDOW_HEIGHT_EDIT 400
+constexpr int ANIM_WINDOW_HEIGHT_NORMAL = 250;
+constexpr int ANIM_WINDOW_HEIGHT_EDIT = 400;
+} // namespace
 
 void App::updateUI() {
     imGuiVirtualWindow->setCurrentImGuiContext();

--- a/app/updateUi.cpp
+++ b/app/updateUi.cpp
@@ -8,9 +8,13 @@
 #include "./motionUtil/bvhExporter.hpp"
 
 namespace {
+// コントロールボタンの1単位サイズ
+// 基本的にこの単位サイズの整数倍の大きさをボタンの大きさに設定する
 constexpr int MAIN_CONTROL_BUTTON_SIZE_UNIT = 40;
 
+// Normalモードのアニメーションウィンドウの高さ
 constexpr int ANIM_WINDOW_HEIGHT_NORMAL = 250;
+// Editモードのアニメーションウィンドウの高さ
 constexpr int ANIM_WINDOW_HEIGHT_EDIT = 400;
 } // namespace
 

--- a/app/updateUi.cpp
+++ b/app/updateUi.cpp
@@ -122,7 +122,9 @@ void updateAnimationControlWindowEditor(bool &modelLoaded,
                                         std::shared_ptr<Animator> animator);
 
 void App::updateAnimationControlWindow() {
-    initAnimationControlWindowSize(mainWindow, ui->animationControlWindow);
+    if (!ui->animationControlWindow.windowInitialized) {
+        initAnimationControlWindowSize(mainWindow, ui->animationControlWindow);
+    }
 
     ImGui::Begin(u8"アニメーションコントロール");
 
@@ -157,9 +159,6 @@ void initAnimationControlWindowSize(
     const std::shared_ptr<ikura::GlfwNativeWindow> &mainWindow,
     UI::AnimationControlWindow &ctx) {
 
-    if (ctx.windowInitialized)
-        return;
-
     const auto modeIndex = ctx.modeIndex;
 
     int width, height;
@@ -174,20 +173,20 @@ void initAnimationControlWindowSize(
         msg += "アニメーションウィンドウのmodeIndexが不正です: ";
         msg += std::to_string(modeIndex);
         throw std::runtime_error(msg);
-        }
+    }
 
-        const auto posX = (mainWindow->getWidth() - width) / 2;
-        const auto posY =
-            mainWindow->getHeight() - height - ANIM_WINDOW_BOTTOM_MARGIN;
+    const auto posX = (mainWindow->getWidth() - width) / 2;
+    const auto posY =
+        mainWindow->getHeight() - height - ANIM_WINDOW_BOTTOM_MARGIN;
 
-        const auto newWindowSize =
-            ImVec2(static_cast<float>(width), static_cast<float>(height));
-        const auto newWindowPos =
-            ImVec2(static_cast<float>(posX), static_cast<float>(posY));
+    const auto newWindowSize =
+        ImVec2(static_cast<float>(width), static_cast<float>(height));
+    const auto newWindowPos =
+        ImVec2(static_cast<float>(posX), static_cast<float>(posY));
 
-        ImGui::SetNextWindowSize(newWindowSize);
-        ImGui::SetNextWindowPos(newWindowPos);
-        ctx.windowInitialized = true;
+    ImGui::SetNextWindowSize(newWindowSize);
+    ImGui::SetNextWindowPos(newWindowPos);
+    ctx.windowInitialized = true;
 }
 
 void updateAnimationControlWindowModeSwitcher(

--- a/app/updateUi.cpp
+++ b/app/updateUi.cpp
@@ -157,21 +157,23 @@ void initAnimationControlWindowSize(
     const std::shared_ptr<ikura::GlfwNativeWindow> &mainWindow,
     UI::AnimationControlWindow &ctx) {
 
-    if (!ctx.windowInitialized) {
-        const auto modeIndex = ctx.modeIndex;
+    if (ctx.windowInitialized)
+        return;
 
-        int width, height;
-        if (modeIndex == UI::AnimationControlWindow::MODE_INDEX_NORMAL) {
-            width = ANIM_WINDOW_WIDTH;
-            height = ANIM_WINDOW_HEIGHT_NORMAL;
-        } else if (modeIndex == UI::AnimationControlWindow::MODE_INDEX_EDIT) {
-            width = ANIM_WINDOW_WIDTH;
-            height = ANIM_WINDOW_HEIGHT_EDIT;
-        } else {
-            std::string msg;
-            msg += "アニメーションウィンドウのmodeIndexが不正です: ";
-            msg += std::to_string(modeIndex);
-            throw std::runtime_error(msg);
+    const auto modeIndex = ctx.modeIndex;
+
+    int width, height;
+    if (modeIndex == UI::AnimationControlWindow::MODE_INDEX_NORMAL) {
+        width = ANIM_WINDOW_WIDTH;
+        height = ANIM_WINDOW_HEIGHT_NORMAL;
+    } else if (modeIndex == UI::AnimationControlWindow::MODE_INDEX_EDIT) {
+        width = ANIM_WINDOW_WIDTH;
+        height = ANIM_WINDOW_HEIGHT_EDIT;
+    } else {
+        std::string msg;
+        msg += "アニメーションウィンドウのmodeIndexが不正です: ";
+        msg += std::to_string(modeIndex);
+        throw std::runtime_error(msg);
         }
 
         const auto posX = (mainWindow->getWidth() - width) / 2;
@@ -186,7 +188,6 @@ void initAnimationControlWindowSize(
         ImGui::SetNextWindowSize(newWindowSize);
         ImGui::SetNextWindowPos(newWindowPos);
         ctx.windowInitialized = true;
-    }
 }
 
 void updateAnimationControlWindowModeSwitcher(

--- a/app/updateUi.cpp
+++ b/app/updateUi.cpp
@@ -12,10 +12,16 @@ namespace {
 // 基本的にこの単位サイズの整数倍の大きさをボタンの大きさに設定する
 constexpr int MAIN_CONTROL_BUTTON_SIZE_UNIT = 40;
 
-// Normalモードのアニメーションウィンドウの高さ
+// アニメーションコントールウィンドウの幅
+constexpr int ANIM_WINDOW_WIDTH = 800;
+
+// Normalモードのアニメーションコントロールウィンドウの高さ
 constexpr int ANIM_WINDOW_HEIGHT_NORMAL = 250;
-// Editモードのアニメーションウィンドウの高さ
+// Editモードのアニメーションコントロールウィンドウの高さ
 constexpr int ANIM_WINDOW_HEIGHT_EDIT = 400;
+
+// アニメーションコントロールウィンドウの下端からウィンドウの下端までのマージン
+constexpr int ANIM_WINDOW_BOTTOM_MARGIN = 10;
 } // namespace
 
 void App::updateUI() {
@@ -158,17 +164,20 @@ void initAnimationControlWindowSize(
 
         // Normal mode
         if (modeIndex == ctx.MODE_INDEX_NORMAL) {
-            newWindowSize = ImVec2(800, ANIM_WINDOW_HEIGHT_NORMAL);
-            newWindowPos = ImVec2((mainWindow->getWidth() - 800) / 2,
-                                  mainWindow->getHeight() -
-                                      ANIM_WINDOW_HEIGHT_NORMAL - 10);
+            newWindowSize =
+                ImVec2(ANIM_WINDOW_WIDTH, ANIM_WINDOW_HEIGHT_NORMAL);
+            newWindowPos =
+                ImVec2((mainWindow->getWidth() - ANIM_WINDOW_WIDTH) / 2,
+                       mainWindow->getHeight() - ANIM_WINDOW_HEIGHT_NORMAL -
+                           ANIM_WINDOW_BOTTOM_MARGIN);
         }
         // Edit mode
         else if (modeIndex == ctx.MODE_INDEX_EDIT) {
-            newWindowSize = ImVec2(800, ANIM_WINDOW_HEIGHT_EDIT);
+            newWindowSize = ImVec2(ANIM_WINDOW_WIDTH, ANIM_WINDOW_HEIGHT_EDIT);
             newWindowPos =
-                ImVec2((mainWindow->getWidth() - 800) / 2,
-                       mainWindow->getHeight() - ANIM_WINDOW_HEIGHT_EDIT - 10);
+                ImVec2((mainWindow->getWidth() - ANIM_WINDOW_WIDTH) / 2,
+                       mainWindow->getHeight() - ANIM_WINDOW_HEIGHT_EDIT -
+                           ANIM_WINDOW_BOTTOM_MARGIN);
         }
 
         ImGui::SetNextWindowSize(newWindowSize);

--- a/app/updateUi.cpp
+++ b/app/updateUi.cpp
@@ -161,13 +161,13 @@ void initAnimationControlWindowSize(
 
     const auto modeIndex = ctx.modeIndex;
 
-    int width, height;
+    int animWindowWidth, animWindowHeight;
     if (modeIndex == UI::AnimationControlWindow::MODE_INDEX_NORMAL) {
-        width = ANIM_WINDOW_WIDTH;
-        height = ANIM_WINDOW_HEIGHT_NORMAL;
+        animWindowWidth = ANIM_WINDOW_WIDTH;
+        animWindowHeight = ANIM_WINDOW_HEIGHT_NORMAL;
     } else if (modeIndex == UI::AnimationControlWindow::MODE_INDEX_EDIT) {
-        width = ANIM_WINDOW_WIDTH;
-        height = ANIM_WINDOW_HEIGHT_EDIT;
+        animWindowWidth = ANIM_WINDOW_WIDTH;
+        animWindowHeight = ANIM_WINDOW_HEIGHT_EDIT;
     } else {
         std::string msg;
         msg += "アニメーションウィンドウのmodeIndexが不正です: ";
@@ -175,14 +175,20 @@ void initAnimationControlWindowSize(
         throw std::runtime_error(msg);
     }
 
-    const auto posX = (mainWindow->getWidth() - width) / 2;
-    const auto posY =
-        mainWindow->getHeight() - height - ANIM_WINDOW_BOTTOM_MARGIN;
+    const float nativeWindowWidthScaled =
+        static_cast<float>(mainWindow->getWidth()) / mainWindow->getScaleX();
+    const float nativeWindowHeightScaled =
+        static_cast<float>(mainWindow->getHeight()) / mainWindow->getScaleY();
 
-    const auto newWindowSize =
-        ImVec2(static_cast<float>(width), static_cast<float>(height));
-    const auto newWindowPos =
-        ImVec2(static_cast<float>(posX), static_cast<float>(posY));
+    const auto posX =
+        (nativeWindowWidthScaled - static_cast<float>(animWindowWidth)) / 2;
+    const auto posY = nativeWindowHeightScaled -
+                      static_cast<float>(animWindowHeight) -
+                      ANIM_WINDOW_BOTTOM_MARGIN;
+
+    const auto newWindowSize = ImVec2(static_cast<float>(animWindowWidth),
+                                      static_cast<float>(animWindowHeight));
+    const auto newWindowPos = ImVec2(posX, posY);
 
     ImGui::SetNextWindowSize(newWindowSize);
     ImGui::SetNextWindowPos(newWindowPos);

--- a/app/updateUi.cpp
+++ b/app/updateUi.cpp
@@ -429,6 +429,7 @@ void App::updateDebugWindow() {
     // window status
     ImGui::Text("Window size: (%d, %d)", mainWindow->getWidth(),
                 mainWindow->getHeight());
+    ImGui::Text("Window scale: (%f, %f)", mainWindow->getScaleX(), mainWindow->getScaleY());
     ImGui::Text("IsWindowFocused: %d", ImGui::IsWindowFocused());
 
     ImGui::End();

--- a/app/updateUi.cpp
+++ b/app/updateUi.cpp
@@ -107,7 +107,7 @@ void App::updateMainMenu() {
 // ----------------------------------------
 
 void initAnimationControlWindowSize(
-    std::shared_ptr<ikura::GlfwNativeWindow> mainWindow,
+    const std::shared_ptr<ikura::GlfwNativeWindow> &mainWindow,
     UI::AnimationControlWindow &ctx);
 void updateAnimationControlWindowModeSwitcher(
     UI::AnimationControlWindow &ctx, std::shared_ptr<Animator> animator);
@@ -154,31 +154,34 @@ void App::updateAnimationControlWindow() {
 }
 
 void initAnimationControlWindowSize(
-    std::shared_ptr<ikura::GlfwNativeWindow> mainWindow,
+    const std::shared_ptr<ikura::GlfwNativeWindow> &mainWindow,
     UI::AnimationControlWindow &ctx) {
 
     if (!ctx.windowInitialized) {
-        ImVec2 newWindowSize;
-        ImVec2 newWindowPos;
-        auto modeIndex = ctx.modeIndex;
+        const auto modeIndex = ctx.modeIndex;
 
-        // Normal mode
-        if (modeIndex == ctx.MODE_INDEX_NORMAL) {
-            newWindowSize =
-                ImVec2(ANIM_WINDOW_WIDTH, ANIM_WINDOW_HEIGHT_NORMAL);
-            newWindowPos =
-                ImVec2((mainWindow->getWidth() - ANIM_WINDOW_WIDTH) / 2,
-                       mainWindow->getHeight() - ANIM_WINDOW_HEIGHT_NORMAL -
-                           ANIM_WINDOW_BOTTOM_MARGIN);
+        int width, height;
+        if (modeIndex == UI::AnimationControlWindow::MODE_INDEX_NORMAL) {
+            width = ANIM_WINDOW_WIDTH;
+            height = ANIM_WINDOW_HEIGHT_NORMAL;
+        } else if (modeIndex == UI::AnimationControlWindow::MODE_INDEX_EDIT) {
+            width = ANIM_WINDOW_WIDTH;
+            height = ANIM_WINDOW_HEIGHT_EDIT;
+        } else {
+            std::string msg;
+            msg += "アニメーションウィンドウのmodeIndexが不正です: ";
+            msg += std::to_string(modeIndex);
+            throw std::runtime_error(msg);
         }
-        // Edit mode
-        else if (modeIndex == ctx.MODE_INDEX_EDIT) {
-            newWindowSize = ImVec2(ANIM_WINDOW_WIDTH, ANIM_WINDOW_HEIGHT_EDIT);
-            newWindowPos =
-                ImVec2((mainWindow->getWidth() - ANIM_WINDOW_WIDTH) / 2,
-                       mainWindow->getHeight() - ANIM_WINDOW_HEIGHT_EDIT -
-                           ANIM_WINDOW_BOTTOM_MARGIN);
-        }
+
+        const auto posX = (mainWindow->getWidth() - width) / 2;
+        const auto posY =
+            mainWindow->getHeight() - height - ANIM_WINDOW_BOTTOM_MARGIN;
+
+        const auto newWindowSize =
+            ImVec2(static_cast<float>(width), static_cast<float>(height));
+        const auto newWindowPos =
+            ImVec2(static_cast<float>(posX), static_cast<float>(posY));
 
         ImGui::SetNextWindowSize(newWindowSize);
         ImGui::SetNextWindowPos(newWindowPos);

--- a/app/updateUi.cpp
+++ b/app/updateUi.cpp
@@ -155,6 +155,17 @@ void App::updateAnimationControlWindow() {
     ImGui::End();
 }
 
+/**
+ * @brief アニメーションコントロールウィンドウの初期サイズと初期位置を設定する。
+ * 
+ * Retinaディスプレイなど、ウィンドウのスケールが1.0以外の場合も考慮する。
+ * VulkanによるレンダリングはRetinaディスプレイの論理ピクセルベースで行っている。
+ * 一方で、Dear ImGuiは物理ピクセルベースでレンダリングを行う。
+ * したがって、OSウィンドウのサイズはスケーリング後のものを使用する。
+ * 
+ * @param mainWindow メインウィンドウのGLFWウィンドウ
+ * @param ctx アニメーションコントロールウィンドウのコンテキスト
+ */
 void initAnimationControlWindowSize(
     const std::shared_ptr<ikura::GlfwNativeWindow> &mainWindow,
     UI::AnimationControlWindow &ctx) {

--- a/core/ikura/window/nativeWindow/glfwNativeWindow.cpp
+++ b/core/ikura/window/nativeWindow/glfwNativeWindow.cpp
@@ -72,6 +72,20 @@ GlfwNativeWindow::~GlfwNativeWindow() {
     }
 }
 
+float GlfwNativeWindow::getScaleX() const {
+    float xScale;
+    glfwGetWindowContentScale(window, &xScale, nullptr);
+
+    return xScale;
+}
+
+float GlfwNativeWindow::getScaleY() const {
+    float yScale;
+    glfwGetWindowContentScale(window, nullptr, &yScale);
+
+    return yScale;
+}
+
 void GlfwNativeWindow::createSwapChain() {
     VLOG(VLOG_LV_3_PROCESS_TRACKING)
         << "Creating SwapChain for '" << name << "'...";

--- a/core/ikura/window/nativeWindow/glfwNativeWindow.hpp
+++ b/core/ikura/window/nativeWindow/glfwNativeWindow.hpp
@@ -30,6 +30,9 @@ class GlfwNativeWindow : public NativeWindow {
                      std::string name);
     ~GlfwNativeWindow();
 
+    float getScaleX() const override;
+    float getScaleY() const override;
+
     void destroyResources() override;
     void draw() override;
     bool closed() override;

--- a/core/ikura/window/window.hpp
+++ b/core/ikura/window/window.hpp
@@ -37,6 +37,9 @@ class Window {
     const std::shared_ptr<RenderTarget> &getRenderTarget();
     const std::shared_ptr<RenderContent> &getRenderContent();
 
+    virtual float getScaleX() const { return 1.0f; };
+    virtual float getScaleY() const { return 1.0f; };
+
     // Setters ----------
     void setRenderTarget(std::shared_ptr<RenderTarget> renderTarget);
     void setRenderContent(std::shared_ptr<RenderContent> renderContent);


### PR DESCRIPTION
これまで、MacOSでikulab-motion-viewerを実行するとアニメーションウィンドウの初期位置が右下に大きくズレるという不具合があった↓

<img width="700px" alt="image" src="https://github.com/user-attachments/assets/eaf1315a-0178-4916-98e8-d174a8c641fb">

これはMacOSのRetinaディスプレイ上で実行したときの不具合だった。
本PRではこれを修正し、Retinaディスプレイ上で実行したときでもアニメーションコントロールウィンドウの位置が正しくなるようにした↓

<img width="700" alt="image" src="https://github.com/user-attachments/assets/abc8caff-4838-46c9-9f5e-60dfb3abbdf7">
