### PR TITLE
WIndows用の修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ target_link_libraries(ikulab-motion-viewer PRIVATE glm::glm)
 if (WIN32)
     # リソースファイルを追加
     target_sources(ikulab-motion-viewer PRIVATE assets/windows/icon.rc)
+    # build as Windows GUI application (set entry point to WinMain)
+    set_target_properties(ikulab-motion-viewer PROPERTIES WIN32_EXECUTABLE TRUE)
 endif ()
 
 # ------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_libraries(ikulab-motion-viewer PRIVATE tinyfiledialogs::tinyfiledial
 target_link_libraries(ikulab-motion-viewer PRIVATE glm::glm)
 
 if (WIN32)
-    # リソースファイルを追加
+    # add resource file
     target_sources(ikulab-motion-viewer PRIVATE assets/windows/icon.rc)
     # build as Windows GUI application (set entry point to WinMain)
     set_target_properties(ikulab-motion-viewer PROPERTIES WIN32_EXECUTABLE TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,12 @@ target_link_libraries(ikulab-motion-viewer PRIVATE glm::glm)
 if (WIN32)
     # add resource file
     target_sources(ikulab-motion-viewer PRIVATE assets/windows/icon.rc)
-    # build as Windows GUI application (set entry point to WinMain)
-    set_target_properties(ikulab-motion-viewer PROPERTIES WIN32_EXECUTABLE TRUE)
+
+    # if FORCE_USE_CPP_MAIN is not defined
+    if (NOT DEFINED FORCE_USE_CPP_MAIN)
+        # build as Windows GUI application (set entry point to WinMain)
+        set_target_properties(ikulab-motion-viewer PROPERTIES WIN32_EXECUTABLE TRUE)
+    endif ()
 endif ()
 
 # ------------------------------------------------------------

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,7 +16,8 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-        "RESOURCE_DIR": "${sourceDir}/assets"
+        "RESOURCE_DIR": "${sourceDir}/assets",
+        "FORCE_USE_CPP_MAIN": "ON"
       }
     },
     {

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -12,6 +12,10 @@
 
 INITIALIZE_EASYLOGGINGPP
 
+#ifdef IS_WINDOWS
+#include <windows.h>
+#endif
+
 void initEasyloggingpp() {
     el::Configurations conf;
     conf.setToDefault();
@@ -29,7 +33,7 @@ void initEasyloggingpp() {
     el::Loggers::reconfigureAllLoggers(conf);
 }
 
-int main(int argc, const char **argv) {
+int main(int argc, char **argv) {
     initEasyloggingpp();
 
     if (argc > 1) {
@@ -61,3 +65,30 @@ int main(int argc, const char **argv) {
 
     return EXIT_SUCCESS;
 }
+
+#ifdef IS_WINDOWS
+/**
+ * @brief Entry point for Windows.
+ *
+ * Convert the command line arguments to char* list and call main().
+ */
+int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
+                     LPSTR lpCmdLine, int nCmdShow) {
+    auto cmdLine = GetCommandLineW();
+
+    int argc;
+    auto argvWin32 = CommandLineToArgvW(cmdLine, &argc);
+
+    std::vector<char *> argv;
+    for (int i = 0; i < argc; i++) {
+        auto arg = argvWin32[i];
+        auto len = wcslen(arg);
+        auto buf = new char[len + 1];
+        wcstombs(buf, arg, len);
+        buf[len] = '\0';
+        argv.push_back(buf);
+    }
+
+    return main(argc, argv.data());
+}
+#endif

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -20,6 +20,10 @@ void initEasyloggingpp() {
     auto logFilePath =
         getHomeDirectory() / "Library" / "Logs" / "ikulab-motion-viewer.log";
     conf.set(el::Level::Global, el::ConfigurationType::Filename, logFilePath);
+#elif IS_WINDOWS
+    auto logFilePath = getResourceDirectory() / "ikulab-motion-viewer.log";
+    conf.set(el::Level::Global, el::ConfigurationType::Filename,
+             logFilePath.string());
 #endif
 
     el::Loggers::reconfigureAllLoggers(conf);

--- a/app/resourceDirectory.cpp
+++ b/app/resourceDirectory.cpp
@@ -112,7 +112,7 @@ std::filesystem::path getHomeDirectory() {
 
     std::filesystem::path homeDrive = getenv("HOMEDRIVE");
     std::filesystem::path homePath = getenv("HOMEPATH");
-    
+
     return homeDrive / homePath;
 }
 #endif

--- a/app/resourceDirectory.cpp
+++ b/app/resourceDirectory.cpp
@@ -3,6 +3,8 @@
 #ifdef __APPLE__
 #include <CoreFoundation/CoreFoundation.h>
 #include <mach-o/dyld.h>
+#elif IS_WINDOWS
+#include <windows.h>
 #endif
 
 #include <tinyfiledialogs.h>
@@ -80,9 +82,10 @@ std::filesystem::path getResourceDirectory() {
 #elif IS_WINDOWS
 
 std::filesystem::path getResourceDirectory() {
-    std::filesystem::path homeDrive = getenv("HOMEDRIVE");
-    std::filesystem::path homePath = getenv("HOMEPATH");
-    std::filesystem::path resourceDir = homeDrive / homePath / ".ikulab-motion-viewer";
+    char buffer[MAX_PATH];
+    GetModuleFileName(nullptr, buffer, MAX_PATH);
+    const std::filesystem::path path = buffer;
+    std::filesystem::path resourceDir = path.parent_path();
 
     return resourceDir;
 }


### PR DESCRIPTION
その1

リソースディレクトリを修正した。
`~/.ikulab-motion-viewer` ではなく、exeファイルのディレクトリをリソースディレクトリにした。

その2

Windows GUIアプリとしてビルドするようにした。
これによって、IDE以外から起動した時も標準出力用コンソールが立ち上がらないようにした。
ただし、CMakePresets.jsonから `FORCE_USE_CPP_MAIN` を `ON` にすると、Windows用ビルドであってもコンソールアプリとしてビルドされる。

あとはコードフォーマットの修正とコメントの英語化