### PR TITLE
includeパスのリファクタリング

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -6,4 +6,5 @@ file(GLOB_RECURSE imv_sources "*.cpp")
 add_executable(ikulab-motion-viewer ${imv_sources})
 
 target_include_directories(ikulab-motion-viewer PUBLIC "${common_include_dir}")
+target_include_directories(ikulab-motion-viewer PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_compile_features(ikulab-motion-viewer PRIVATE cxx_std_17)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -5,6 +5,6 @@ file(GLOB_RECURSE imv_sources "*.cpp")
 
 add_executable(ikulab-motion-viewer ${imv_sources})
 
-target_include_directories(ikulab-motion-viewer PUBLIC "${common_include_dir}")
+target_include_directories(ikulab-motion-viewer PRIVATE "${common_include_dir}")
 target_include_directories(ikulab-motion-viewer PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_compile_features(ikulab-motion-viewer PRIVATE cxx_std_17)

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -1,4 +1,4 @@
-#include "./app.hpp"
+#include "app.hpp"
 
 #include <algorithm>
 #include <iostream>
@@ -12,11 +12,11 @@
 
 #include <tinyfiledialogs.h>
 
-#include "./motionUtil/bvhExporter.hpp"
-#include "./resourceDirectory.hpp"
-#include "./util/popupUtils.hpp"
-#include "./util/errorUtils.hpp"
-#include "./buildInfo.h"
+#include "motionUtil/bvhExporter.hpp"
+#include "resourceDirectory.hpp"
+#include "util/popupUtils.hpp"
+#include "util/errorUtils.hpp"
+#include "buildInfo.h"
 
 void App::initIkura() {
     // Initialize Ikura

--- a/src/app/app.hpp
+++ b/src/app/app.hpp
@@ -4,11 +4,11 @@
 
 #include <ikura/ikura.hpp>
 
-#include "./context/camera.hpp"
-#include "./context/keyboard.hpp"
-#include "./context/mouse.hpp"
-#include "./context/ui.hpp"
-#include "./motionUtil/animator.hpp"
+#include "context/camera.hpp"
+#include "context/keyboard.hpp"
+#include "context/mouse.hpp"
+#include "context/ui.hpp"
+#include "motionUtil/animator.hpp"
 
 class App {
     // Variables ==========

--- a/src/app/callbacks.cpp
+++ b/src/app/callbacks.cpp
@@ -1,4 +1,4 @@
-#include "./app.hpp"
+#include "app.hpp"
 
 void App::cursorPositionCallback(GLFWwindow *window, double xPos, double yPos) {
     App *app = static_cast<App *>(glfwGetWindowUserPointer(window));

--- a/src/app/context/camera.cpp
+++ b/src/app/context/camera.cpp
@@ -1,4 +1,4 @@
-#include "./camera.hpp"
+#include "camera.hpp"
 
 void Camera::init() {
     center = {0.0, 0.0, 5.0};

--- a/src/app/context/camera.hpp
+++ b/src/app/context/camera.hpp
@@ -9,8 +9,8 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
-#include "./keyboard.hpp"
-#include "./mouse.hpp"
+#include "keyboard.hpp"
+#include "mouse.hpp"
 
 class Camera {
   public:

--- a/src/app/context/mouse.cpp
+++ b/src/app/context/mouse.cpp
@@ -1,4 +1,4 @@
-#include "./mouse.hpp"
+#include "mouse.hpp"
 
 void Mouse::reset() {
     scrollOffsetX = 0;

--- a/src/app/context/ui.cpp
+++ b/src/app/context/ui.cpp
@@ -1,4 +1,4 @@
-#include "./ui.hpp"
+#include "ui.hpp"
 
 void UI::makePadding(int pad) {
     ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (pad));

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -6,9 +6,9 @@
 
 #include <easylogging++.h>
 
-#include "./resourceDirectory.hpp"
-#include "./versionChecker.hpp"
-#include "./util/errorUtils.hpp"
+#include "resourceDirectory.hpp"
+#include "versionChecker.hpp"
+#include "util/errorUtils.hpp"
 
 INITIALIZE_EASYLOGGINGPP
 

--- a/src/app/motionUtil/animator.cpp
+++ b/src/app/motionUtil/animator.cpp
@@ -5,8 +5,8 @@
 #define GLM_FORCE_RADIANS
 #include <glm/gtc/matrix_transform.hpp>
 
-#include "./animator.hpp"
-#include "./bvhParser.hpp"
+#include "animator.hpp"
+#include "bvhParser.hpp"
 
 // ----------------------------------------
 // Animator::Joint

--- a/src/app/motionUtil/animator.hpp
+++ b/src/app/motionUtil/animator.hpp
@@ -11,8 +11,8 @@
 
 #include <ikura/ikura.hpp>
 
-#include "../context/ui.hpp"
 #include "common.hpp"
+#include "context/ui.hpp"
 
 #define MAX_ANIMATION_SPEED 10.0f
 #define MIN_ANIMATION_SPEED (1.0f / 128.0f)

--- a/src/app/motionUtil/animator.hpp
+++ b/src/app/motionUtil/animator.hpp
@@ -12,7 +12,7 @@
 #include <ikura/ikura.hpp>
 
 #include "../context/ui.hpp"
-#include "./common.hpp"
+#include "common.hpp"
 
 #define MAX_ANIMATION_SPEED 10.0f
 #define MIN_ANIMATION_SPEED (1.0f / 128.0f)

--- a/src/app/motionUtil/bvhExporter.cpp
+++ b/src/app/motionUtil/bvhExporter.cpp
@@ -1,9 +1,9 @@
-#include "./bvhExporter.hpp"
+#include "bvhExporter.hpp"
 
 #include <cstring>
 #include <fstream>
 
-#include "./bvhParser.hpp"
+#include "bvhParser.hpp"
 
 #define INDENT ("  ")
 

--- a/src/app/motionUtil/bvhExporter.hpp
+++ b/src/app/motionUtil/bvhExporter.hpp
@@ -2,7 +2,7 @@
 
 #include <filesystem>
 
-#include "./animator.hpp"
+#include "animator.hpp"
 
 void exportLoopRangeToBvhFile(const std::shared_ptr<Animator> animator,
                               std::filesystem::path destFile,

--- a/src/app/motionUtil/bvhParser.cpp
+++ b/src/app/motionUtil/bvhParser.cpp
@@ -1,4 +1,4 @@
-#include "./bvhParser.hpp"
+#include "bvhParser.hpp"
 
 #include <algorithm>
 #include <fstream>

--- a/src/app/motionUtil/bvhParser.hpp
+++ b/src/app/motionUtil/bvhParser.hpp
@@ -5,8 +5,8 @@
 
 #include <ikura/ikura.hpp>
 
-#include "./animator.hpp"
-#include "./common.hpp"
+#include "animator.hpp"
+#include "common.hpp"
 
 #define TOKEN_TOP "HIERARCHY"
 #define TOKEN_ROOT "ROOT"

--- a/src/app/motionUtil/common.cpp
+++ b/src/app/motionUtil/common.cpp
@@ -1,4 +1,4 @@
-#include "./common.hpp"
+#include "common.hpp"
 
 ChannelEnum convertStrToChannelEnum(std::string str) {
     if (str == "Xposition")

--- a/src/app/resourceDirectory.cpp
+++ b/src/app/resourceDirectory.cpp
@@ -1,4 +1,4 @@
-#include "./resourceDirectory.hpp"
+#include "resourceDirectory.hpp"
 
 #ifdef __APPLE__
 #include <CoreFoundation/CoreFoundation.h>
@@ -8,7 +8,7 @@
 #include <shlobj.h>
 #endif
 
-#include "./util/errorUtils.hpp"
+#include "util/errorUtils.hpp"
 
 // ------------------------------------------------------------
 // getReadOnlyResourceDirectory

--- a/src/app/updateUi.cpp
+++ b/src/app/updateUi.cpp
@@ -1,11 +1,11 @@
-﻿#include "./app.hpp"
+﻿#include "app.hpp"
 
 #include <algorithm>
 #include <cmath>
 
 #include <ikura/third_party/ikura_ext_imgui/imgui.h>
 
-#include "./motionUtil/bvhExporter.hpp"
+#include "motionUtil/bvhExporter.hpp"
 
 namespace {
 // コントロールボタンの1単位サイズ

--- a/src/app/util/popupUtils.cpp
+++ b/src/app/util/popupUtils.cpp
@@ -2,7 +2,7 @@
 // Created by kota.miyakawa on 2024/07/10.
 //
 
-#include "./popupUtils.hpp"
+#include "popupUtils.hpp"
 
 #include <tinyfiledialogs.h>
 

--- a/src/app/versionChecker.hpp
+++ b/src/app/versionChecker.hpp
@@ -6,7 +6,7 @@
 
 #include <easylogging++.h>
 
-#include "./resourceDirectory.hpp"
+#include "resourceDirectory.hpp"
 
 #ifdef IS_WINDOWS
 #include <windows.h>

--- a/src/core/ikura/CMakeLists.txt
+++ b/src/core/ikura/CMakeLists.txt
@@ -41,9 +41,7 @@ target_compile_definitions(ikura PRIVATE VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
 target_compile_definitions(ikura PRIVATE VMA_STATIC_VULKAN_FUNCTIONS=0 VMA_DYNAMIC_VULKAN_FUNCTIONS=1)
 
 # set include directory for applications using ikura
-target_include_directories(ikura INTERFACE ${PROJECT_SOURCE_DIR})
-
-target_include_directories(ikura PRIVATE ${PROJECT_SOURCE_DIR})
+target_include_directories(ikura PUBLIC ${PROJECT_SOURCE_DIR})
 
 # ------------------------------------------------------------
 # link third party libraries

--- a/src/core/ikura/CMakeLists.txt
+++ b/src/core/ikura/CMakeLists.txt
@@ -43,6 +43,8 @@ target_compile_definitions(ikura PRIVATE VMA_STATIC_VULKAN_FUNCTIONS=0 VMA_DYNAM
 # set include directory for applications using ikura
 target_include_directories(ikura INTERFACE ${PROJECT_SOURCE_DIR})
 
+target_include_directories(ikura PRIVATE ${PROJECT_SOURCE_DIR})
+
 # ------------------------------------------------------------
 # link third party libraries
 # ------------------------------------------------------------

--- a/src/core/ikura/CMakeLists.txt
+++ b/src/core/ikura/CMakeLists.txt
@@ -41,10 +41,7 @@ target_compile_definitions(ikura PRIVATE VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
 target_compile_definitions(ikura PRIVATE VMA_STATIC_VULKAN_FUNCTIONS=0 VMA_DYNAMIC_VULKAN_FUNCTIONS=1)
 
 # set include directory for applications using ikura
-target_include_directories(ikura INTERFACE
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-        $<INSTALL_INTERFACE:include/ikura>
-        $<INSTALL_INTERFACE:${common_include_dir}>)
+target_include_directories(ikura INTERFACE ${PROJECT_SOURCE_DIR})
 
 # ------------------------------------------------------------
 # link third party libraries

--- a/src/core/ikura/engine/appEngine.cpp
+++ b/src/core/ikura/engine/appEngine.cpp
@@ -11,7 +11,7 @@
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #include <glm/gtc/matrix_transform.hpp>
 
-#include "../shape/shapes.hpp"
+#include "shape/shapes.hpp"
 
 namespace ikura {
 AppEngine::AppEngine(std::shared_ptr<RenderEngine> renderEngine) {

--- a/src/core/ikura/engine/appEngine.cpp
+++ b/src/core/ikura/engine/appEngine.cpp
@@ -1,4 +1,4 @@
-#include "./appEngine.hpp"
+#include "appEngine.hpp"
 
 #include <algorithm>
 #include <iostream>

--- a/src/core/ikura/engine/appEngine.cpp
+++ b/src/core/ikura/engine/appEngine.cpp
@@ -4,12 +4,12 @@
 #include <iostream>
 #include <thread>
 
-#include <vulkan/vulkan.hpp>
-
-#include <GLFW/glfw3.h>
 #define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
+
+#include <GLFW/glfw3.h>
 #include <glm/gtc/matrix_transform.hpp>
+#include <vulkan/vulkan.hpp>
 
 #include "shape/shapes.hpp"
 

--- a/src/core/ikura/engine/appEngine.hpp
+++ b/src/core/ikura/engine/appEngine.hpp
@@ -5,11 +5,12 @@
 #include <vector>
 
 #define GLFW_INCLUDE_VULKAN
+
 #include <GLFW/glfw3.h>
 
+#include "renderEngine/renderEngine.hpp"
 #include "window/nativeWindow/glfwNativeWindow.hpp"
 #include "window/virtualWindow/imGuiVirtualWindow.hpp"
-#include "renderEngine/renderEngine.hpp"
 
 namespace ikura {
 class AppEngine {

--- a/src/core/ikura/engine/appEngine.hpp
+++ b/src/core/ikura/engine/appEngine.hpp
@@ -9,7 +9,7 @@
 
 #include "../window/nativeWindow/glfwNativeWindow.hpp"
 #include "../window/virtualWindow/imGuiVirtualWindow.hpp"
-#include "./renderEngine/renderEngine.hpp"
+#include "renderEngine/renderEngine.hpp"
 
 namespace ikura {
 class AppEngine {

--- a/src/core/ikura/engine/appEngine.hpp
+++ b/src/core/ikura/engine/appEngine.hpp
@@ -7,8 +7,8 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#include "../window/nativeWindow/glfwNativeWindow.hpp"
-#include "../window/virtualWindow/imGuiVirtualWindow.hpp"
+#include "window/nativeWindow/glfwNativeWindow.hpp"
+#include "window/virtualWindow/imGuiVirtualWindow.hpp"
 #include "renderEngine/renderEngine.hpp"
 
 namespace ikura {

--- a/src/core/ikura/engine/renderEngine/handleExtension.cpp
+++ b/src/core/ikura/engine/renderEngine/handleExtension.cpp
@@ -4,7 +4,7 @@
 
 #include <easylogging++.h>
 
-#include "../../common/logLevels.hpp"
+#include "common/logLevels.hpp"
 
 namespace ikura {
 /**

--- a/src/core/ikura/engine/renderEngine/handleExtension.cpp
+++ b/src/core/ikura/engine/renderEngine/handleExtension.cpp
@@ -1,4 +1,4 @@
-#include "./renderEngine.hpp"
+#include "renderEngine.hpp"
 
 #include <vulkan/vulkan.hpp>
 

--- a/src/core/ikura/engine/renderEngine/initDevice.cpp
+++ b/src/core/ikura/engine/renderEngine/initDevice.cpp
@@ -3,9 +3,8 @@
 #include <map>
 #include <vector>
 
-#include <GLFW/glfw3.h>
-
 #include <easylogging++.h>
+#include <GLFW/glfw3.h>
 #include <vk_mem_alloc.h>
 
 #include "common/logLevels.hpp"

--- a/src/core/ikura/engine/renderEngine/initDevice.cpp
+++ b/src/core/ikura/engine/renderEngine/initDevice.cpp
@@ -1,4 +1,4 @@
-#include "./renderEngine.hpp"
+#include "renderEngine.hpp"
 
 #include <map>
 #include <vector>

--- a/src/core/ikura/engine/renderEngine/initDevice.cpp
+++ b/src/core/ikura/engine/renderEngine/initDevice.cpp
@@ -8,7 +8,7 @@
 #include <easylogging++.h>
 #include <vk_mem_alloc.h>
 
-#include "../../common/logLevels.hpp"
+#include "common/logLevels.hpp"
 
 namespace ikura {
 struct PhysicalDeviceEvaluation {

--- a/src/core/ikura/engine/renderEngine/initInstance.cpp
+++ b/src/core/ikura/engine/renderEngine/initInstance.cpp
@@ -5,7 +5,7 @@
 
 #include <easylogging++.h>
 
-#include "../../common/logLevels.hpp"
+#include "common/logLevels.hpp"
 
 namespace ikura {
 // forward declearation of helper functions ----------

--- a/src/core/ikura/engine/renderEngine/initInstance.cpp
+++ b/src/core/ikura/engine/renderEngine/initInstance.cpp
@@ -1,9 +1,8 @@
 #include "renderEngine.hpp"
 
+#include <easylogging++.h>
 #include <GLFW/glfw3.h>
 #include <vulkan/vulkan.hpp>
-
-#include <easylogging++.h>
 
 #include "common/logLevels.hpp"
 

--- a/src/core/ikura/engine/renderEngine/initInstance.cpp
+++ b/src/core/ikura/engine/renderEngine/initInstance.cpp
@@ -1,4 +1,4 @@
-#include "./renderEngine.hpp"
+#include "renderEngine.hpp"
 
 #include <GLFW/glfw3.h>
 #include <vulkan/vulkan.hpp>

--- a/src/core/ikura/engine/renderEngine/renderEngine.cpp
+++ b/src/core/ikura/engine/renderEngine/renderEngine.cpp
@@ -1,4 +1,4 @@
-#include "./renderEngine.hpp"
+#include "renderEngine.hpp"
 
 #include <GLFW/glfw3.h>
 

--- a/src/core/ikura/engine/renderEngine/renderEngine.cpp
+++ b/src/core/ikura/engine/renderEngine/renderEngine.cpp
@@ -4,7 +4,7 @@
 
 #include <easylogging++.h>
 
-#include "../../common/logLevels.hpp"
+#include "common/logLevels.hpp"
 
 #define VMA_IMPLEMENTATION
 // for compability

--- a/src/core/ikura/engine/renderEngine/renderEngine.cpp
+++ b/src/core/ikura/engine/renderEngine/renderEngine.cpp
@@ -1,11 +1,6 @@
 #include "renderEngine.hpp"
 
-#include <GLFW/glfw3.h>
-
-#include <easylogging++.h>
-
-#include "common/logLevels.hpp"
-
+// TODO(caffeine): maybe unnecessary, determine later
 #define VMA_IMPLEMENTATION
 // for compability
 #ifndef VK_API_VERSION_MAJOR
@@ -17,7 +12,12 @@
 #ifndef VK_API_VERSION_PATCH
 #define VK_API_VERSION_PATCH(version) ((uint32_t)(version)&0xFFFU)
 #endif
+
+#include <easylogging++.h>
+#include <GLFW/glfw3.h>
 #include <vk_mem_alloc.h>
+
+#include "common/logLevels.hpp"
 
 namespace ikura {
 QueueFamilyIndices::QueueFamilyIndices() {

--- a/src/core/ikura/engine/renderEngine/renderEngine.hpp
+++ b/src/core/ikura/engine/renderEngine/renderEngine.hpp
@@ -13,7 +13,7 @@
 
 #include <vk_mem_alloc.h>
 
-#include "../../misc/initVulkanHppDispatchLoader.hpp"
+#include "misc/initVulkanHppDispatchLoader.hpp"
 
 #define VALIDATION_LAYER_NAME "VK_LAYER_KHRONOS_validation"
 #define IKURA_APP_INFO_ENGINE_NAME "Ikura"

--- a/src/core/ikura/engine/renderEngine/renderEngine.hpp
+++ b/src/core/ikura/engine/renderEngine/renderEngine.hpp
@@ -9,9 +9,8 @@
 #include <string>
 #include <vector>
 
-#include <vulkan/vulkan.hpp>
-
 #include <vk_mem_alloc.h>
+#include <vulkan/vulkan.hpp>
 
 #include "misc/initVulkanHppDispatchLoader.hpp"
 

--- a/src/core/ikura/init.cpp
+++ b/src/core/ikura/init.cpp
@@ -2,7 +2,7 @@
 
 #include <easylogging++.h>
 
-#include "./common/logLevels.hpp"
+#include "common/logLevels.hpp"
 
 namespace ikura {
 void init() {

--- a/src/core/ikura/misc/initVulkanHppDispatchLoader.cpp
+++ b/src/core/ikura/misc/initVulkanHppDispatchLoader.cpp
@@ -1,4 +1,4 @@
-#include "./initVulkanHppDispatchLoader.hpp"
+#include "initVulkanHppDispatchLoader.hpp"
 
 #include <memory>
 

--- a/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.cpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.cpp
@@ -2,8 +2,8 @@
 
 #include <easylogging++.h>
 
-#include "descriptorSetProps.hpp"
 #include "common/logLevels.hpp"
+#include "descriptorSetProps.hpp"
 
 namespace ikura {
 void BasicRenderComponentProvider::createDescriptorSetlayout() {

--- a/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.cpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.cpp
@@ -3,8 +3,7 @@
 #include <easylogging++.h>
 
 #include "descriptorSetProps.hpp"
-
-#include "../../common/logLevels.hpp"
+#include "common/logLevels.hpp"
 
 namespace ikura {
 void BasicRenderComponentProvider::createDescriptorSetlayout() {

--- a/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.cpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.cpp
@@ -1,8 +1,8 @@
-#include "./basicRenderComponentProvider.hpp"
+#include "basicRenderComponentProvider.hpp"
 
 #include <easylogging++.h>
 
-#include "./descriptorSetProps.hpp"
+#include "descriptorSetProps.hpp"
 
 #include "../../common/logLevels.hpp"
 

--- a/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.hpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.hpp
@@ -7,8 +7,8 @@
 #include "../../engine/renderEngine/renderEngine.hpp"
 #include "../../window/nativeWindow/nativeWindow.hpp"
 #include "../renderComponentProvider.hpp"
-#include "./basicRenderContent.hpp"
-#include "./basicRenderTarget.hpp"
+#include "basicRenderContent.hpp"
+#include "basicRenderTarget.hpp"
 
 namespace ikura {
 // Provides Basic RenderComponent compatible with shapes

--- a/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.hpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.hpp
@@ -4,11 +4,11 @@
 
 #include <vulkan/vulkan.hpp>
 
-#include "engine/renderEngine/renderEngine.hpp"
-#include "window/nativeWindow/nativeWindow.hpp"
-#include "renderComponent/renderComponentProvider.hpp"
 #include "basicRenderContent.hpp"
 #include "basicRenderTarget.hpp"
+#include "engine/renderEngine/renderEngine.hpp"
+#include "renderComponent/renderComponentProvider.hpp"
+#include "window/nativeWindow/nativeWindow.hpp"
 
 namespace ikura {
 // Provides Basic RenderComponent compatible with shapes

--- a/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.hpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderComponentProvider.hpp
@@ -4,9 +4,9 @@
 
 #include <vulkan/vulkan.hpp>
 
-#include "../../engine/renderEngine/renderEngine.hpp"
-#include "../../window/nativeWindow/nativeWindow.hpp"
-#include "../renderComponentProvider.hpp"
+#include "engine/renderEngine/renderEngine.hpp"
+#include "window/nativeWindow/nativeWindow.hpp"
+#include "renderComponent/renderComponentProvider.hpp"
 #include "basicRenderContent.hpp"
 #include "basicRenderTarget.hpp"
 

--- a/src/core/ikura/renderComponent/basic/basicRenderContent.cpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderContent.cpp
@@ -2,11 +2,11 @@
 
 #include <easylogging++.h>
 
-#include "../../shape/shapes.hpp"
-#include "../../window/window.hpp"
+#include "shape/shapes.hpp"
+#include "window/window.hpp"
 #include "descriptorSetProps.hpp"
 
-#include "../../common/logLevels.hpp"
+#include "common/logLevels.hpp"
 
 // for demo
 #define GLM_FORCE_RADIANS

--- a/src/core/ikura/renderComponent/basic/basicRenderContent.cpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderContent.cpp
@@ -1,10 +1,10 @@
-#include "./basicRenderContent.hpp"
+#include "basicRenderContent.hpp"
 
 #include <easylogging++.h>
 
 #include "../../shape/shapes.hpp"
 #include "../../window/window.hpp"
-#include "./descriptorSetProps.hpp"
+#include "descriptorSetProps.hpp"
 
 #include "../../common/logLevels.hpp"
 

--- a/src/core/ikura/renderComponent/basic/basicRenderContent.cpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderContent.cpp
@@ -2,11 +2,10 @@
 
 #include <easylogging++.h>
 
+#include "common/logLevels.hpp"
+#include "descriptorSetProps.hpp"
 #include "shape/shapes.hpp"
 #include "window/window.hpp"
-#include "descriptorSetProps.hpp"
-
-#include "common/logLevels.hpp"
 
 // for demo
 #define GLM_FORCE_RADIANS

--- a/src/core/ikura/renderComponent/basic/basicRenderContent.hpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderContent.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../renderContent.hpp"
+#include "renderComponent/renderContent.hpp"
 
 namespace ikura {
 // Forward declearation

--- a/src/core/ikura/renderComponent/basic/basicRenderTarget.cpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderTarget.cpp
@@ -2,10 +2,10 @@
 
 #include <easylogging++.h>
 
-#include "../../common/logLevels.hpp"
-#include "../../common/renderPrimitiveTypes.hpp"
-#include "../../misc/shaderCodes.hpp"
-#include "../../util/shaderUtils.hpp"
+#include "common/logLevels.hpp"
+#include "common/renderPrimitiveTypes.hpp"
+#include "misc/shaderCodes.hpp"
+#include "util/shaderUtils.hpp"
 
 namespace ikura {
 void BasicRenderTarget::setupRenderPass() {

--- a/src/core/ikura/renderComponent/basic/basicRenderTarget.cpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderTarget.cpp
@@ -1,4 +1,4 @@
-#include "./basicRenderTarget.hpp"
+#include "basicRenderTarget.hpp"
 
 #include <easylogging++.h>
 

--- a/src/core/ikura/renderComponent/basic/basicRenderTarget.hpp
+++ b/src/core/ikura/renderComponent/basic/basicRenderTarget.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../renderTarget.hpp"
+#include "renderComponent/renderTarget.hpp"
 
 namespace ikura {
 class BasicRenderTarget : public RenderTarget {

--- a/src/core/ikura/renderComponent/renderComponentProvider.cpp
+++ b/src/core/ikura/renderComponent/renderComponentProvider.cpp
@@ -2,7 +2,7 @@
 
 #include <easylogging++.h>
 
-#include "../common/logLevels.hpp"
+#include "common/logLevels.hpp"
 
 namespace ikura {
 RenderComponentProvider::RenderComponentProvider(

--- a/src/core/ikura/renderComponent/renderComponentProvider.cpp
+++ b/src/core/ikura/renderComponent/renderComponentProvider.cpp
@@ -1,4 +1,4 @@
-#include "./renderComponentProvider.hpp"
+#include "renderComponentProvider.hpp"
 
 #include <easylogging++.h>
 

--- a/src/core/ikura/renderComponent/renderComponentProvider.hpp
+++ b/src/core/ikura/renderComponent/renderComponentProvider.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../engine/renderEngine/renderEngine.hpp"
+#include "engine/renderEngine/renderEngine.hpp"
 
 namespace ikura {
 class RenderComponentProvider

--- a/src/core/ikura/renderComponent/renderContent.cpp
+++ b/src/core/ikura/renderComponent/renderContent.cpp
@@ -4,8 +4,8 @@
 
 #include <easylogging++.h>
 
-#include "../window/nativeWindow/nativeWindow.hpp"
-#include "../common/logLevels.hpp"
+#include "window/nativeWindow/nativeWindow.hpp"
+#include "common/logLevels.hpp"
 
 namespace ikura {
 void BufferResource::release(VmaAllocator allocator) {

--- a/src/core/ikura/renderComponent/renderContent.cpp
+++ b/src/core/ikura/renderComponent/renderContent.cpp
@@ -1,11 +1,10 @@
 #include "renderContent.hpp"
 
+#include <easylogging++.h>
 #include <vulkan/vulkan.hpp>
 
-#include <easylogging++.h>
-
-#include "window/nativeWindow/nativeWindow.hpp"
 #include "common/logLevels.hpp"
+#include "window/nativeWindow/nativeWindow.hpp"
 
 namespace ikura {
 void BufferResource::release(VmaAllocator allocator) {

--- a/src/core/ikura/renderComponent/renderContent.cpp
+++ b/src/core/ikura/renderComponent/renderContent.cpp
@@ -1,4 +1,4 @@
-#include "./renderContent.hpp"
+#include "renderContent.hpp"
 
 #include <vulkan/vulkan.hpp>
 

--- a/src/core/ikura/renderComponent/renderContent.hpp
+++ b/src/core/ikura/renderComponent/renderContent.hpp
@@ -4,9 +4,9 @@
 
 #include <glm/glm.hpp>
 
-#include "../common/renderPrimitiveTypes.hpp"
-#include "../common/uniformBufferInfo.hpp"
-#include "../engine/renderEngine/renderEngine.hpp"
+#include "common/renderPrimitiveTypes.hpp"
+#include "common/uniformBufferInfo.hpp"
+#include "engine/renderEngine/renderEngine.hpp"
 #include "renderComponentProvider.hpp"
 
 namespace ikura {

--- a/src/core/ikura/renderComponent/renderContent.hpp
+++ b/src/core/ikura/renderComponent/renderContent.hpp
@@ -7,7 +7,7 @@
 #include "../common/renderPrimitiveTypes.hpp"
 #include "../common/uniformBufferInfo.hpp"
 #include "../engine/renderEngine/renderEngine.hpp"
-#include "./renderComponentProvider.hpp"
+#include "renderComponentProvider.hpp"
 
 namespace ikura {
 class BufferResource {

--- a/src/core/ikura/renderComponent/renderContent.hpp
+++ b/src/core/ikura/renderComponent/renderContent.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <vulkan/vulkan.hpp>
-
 #include <glm/glm.hpp>
+#include <vulkan/vulkan.hpp>
 
 #include "common/renderPrimitiveTypes.hpp"
 #include "common/uniformBufferInfo.hpp"

--- a/src/core/ikura/renderComponent/renderTarget.cpp
+++ b/src/core/ikura/renderComponent/renderTarget.cpp
@@ -3,15 +3,13 @@
 #include <array>
 
 #include <easylogging++.h>
+#include <tinyfiledialogs/tinyfiledialogs.h>
 #include <vk_mem_alloc.h>
 #include <vulkan/vulkan.hpp>
 
-#include "window/nativeWindow/nativeWindow.hpp"
-
 #include "common/logLevels.hpp"
 #include "misc/shaderCodes.hpp"
-
-#include <tinyfiledialogs/tinyfiledialogs.h>
+#include "window/nativeWindow/nativeWindow.hpp"
 
 namespace ikura {
 void ImageResource::release(vk::Device device, VmaAllocator allocator) {

--- a/src/core/ikura/renderComponent/renderTarget.cpp
+++ b/src/core/ikura/renderComponent/renderTarget.cpp
@@ -1,4 +1,4 @@
-#include "./renderTarget.hpp"
+#include "renderTarget.hpp"
 
 #include <array>
 

--- a/src/core/ikura/renderComponent/renderTarget.cpp
+++ b/src/core/ikura/renderComponent/renderTarget.cpp
@@ -6,10 +6,10 @@
 #include <vk_mem_alloc.h>
 #include <vulkan/vulkan.hpp>
 
-#include "../window/nativeWindow/nativeWindow.hpp"
+#include "window/nativeWindow/nativeWindow.hpp"
 
-#include "../common/logLevels.hpp"
-#include "../misc/shaderCodes.hpp"
+#include "common/logLevels.hpp"
+#include "misc/shaderCodes.hpp"
 
 #include <tinyfiledialogs/tinyfiledialogs.h>
 

--- a/src/core/ikura/renderComponent/renderTarget.hpp
+++ b/src/core/ikura/renderComponent/renderTarget.hpp
@@ -7,7 +7,7 @@
 
 #include <vulkan/vulkan.hpp>
 
-#include "../engine/renderEngine/renderEngine.hpp"
+#include "engine/renderEngine/renderEngine.hpp"
 #include "renderComponentProvider.hpp"
 
 namespace ikura {

--- a/src/core/ikura/renderComponent/renderTarget.hpp
+++ b/src/core/ikura/renderComponent/renderTarget.hpp
@@ -8,7 +8,7 @@
 #include <vulkan/vulkan.hpp>
 
 #include "../engine/renderEngine/renderEngine.hpp"
-#include "./renderComponentProvider.hpp"
+#include "renderComponentProvider.hpp"
 
 namespace ikura {
 class ImageResource {

--- a/src/core/ikura/shape/bone/bone.cpp
+++ b/src/core/ikura/shape/bone/bone.cpp
@@ -1,9 +1,10 @@
+#include "bone.hpp"
+
 #include <cmath>
 #include <glm/glm.hpp>
 #include <vector>
 
 #include "shape/sphere/sphere.hpp"
-#include "bone.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/bone/bone.cpp
+++ b/src/core/ikura/shape/bone/bone.cpp
@@ -2,7 +2,7 @@
 #include <glm/glm.hpp>
 #include <vector>
 
-#include "../sphere/sphere.hpp"
+#include "shape/sphere/sphere.hpp"
 #include "bone.hpp"
 
 namespace ikura {

--- a/src/core/ikura/shape/bone/bone.cpp
+++ b/src/core/ikura/shape/bone/bone.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 #include "../sphere/sphere.hpp"
-#include "./bone.hpp"
+#include "bone.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/bone/bone.hpp
+++ b/src/core/ikura/shape/bone/bone.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../shape.hpp"
+#include "shape/shape.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/bone/octahedronBone.cpp
+++ b/src/core/ikura/shape/bone/octahedronBone.cpp
@@ -1,4 +1,5 @@
 #include "octahedronBone.hpp"
+
 #include "shape/sphere/singleColorSphere.hpp"
 
 namespace ikura {

--- a/src/core/ikura/shape/bone/octahedronBone.cpp
+++ b/src/core/ikura/shape/bone/octahedronBone.cpp
@@ -1,5 +1,5 @@
 #include "octahedronBone.hpp"
-#include "../sphere/singleColorSphere.hpp"
+#include "shape/sphere/singleColorSphere.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/bone/octahedronBone.cpp
+++ b/src/core/ikura/shape/bone/octahedronBone.cpp
@@ -1,4 +1,4 @@
-#include "./octahedronBone.hpp"
+#include "octahedronBone.hpp"
 #include "../sphere/singleColorSphere.hpp"
 
 namespace ikura {

--- a/src/core/ikura/shape/bone/octahedronBone.hpp
+++ b/src/core/ikura/shape/bone/octahedronBone.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "./bone.hpp"
+#include "bone.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/bone/stickTetrahedronBone.cpp
+++ b/src/core/ikura/shape/bone/stickTetrahedronBone.cpp
@@ -4,7 +4,7 @@
 
 #include <glm/glm.hpp>
 
-#include "../cube/singleColorCube.hpp"
+#include "shape/cube/singleColorCube.hpp"
 #include "stickTetrahedronBone.hpp"
 
 namespace ikura {

--- a/src/core/ikura/shape/bone/stickTetrahedronBone.cpp
+++ b/src/core/ikura/shape/bone/stickTetrahedronBone.cpp
@@ -1,3 +1,5 @@
+#include "stickTetrahedronBone.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <memory>
@@ -5,7 +7,6 @@
 #include <glm/glm.hpp>
 
 #include "shape/cube/singleColorCube.hpp"
-#include "stickTetrahedronBone.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/bone/stickTetrahedronBone.cpp
+++ b/src/core/ikura/shape/bone/stickTetrahedronBone.cpp
@@ -5,7 +5,7 @@
 #include <glm/glm.hpp>
 
 #include "../cube/singleColorCube.hpp"
-#include "./stickTetrahedronBone.hpp"
+#include "stickTetrahedronBone.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/bone/stickTetrahedronBone.hpp
+++ b/src/core/ikura/shape/bone/stickTetrahedronBone.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <vector>
 
-#include "../cube/singleColorCube.hpp"
+#include "shape/cube/singleColorCube.hpp"
 #include "bone.hpp"
 
 namespace ikura {

--- a/src/core/ikura/shape/bone/stickTetrahedronBone.hpp
+++ b/src/core/ikura/shape/bone/stickTetrahedronBone.hpp
@@ -4,8 +4,8 @@
 #include <memory>
 #include <vector>
 
-#include "shape/cube/singleColorCube.hpp"
 #include "bone.hpp"
+#include "shape/cube/singleColorCube.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/bone/stickTetrahedronBone.hpp
+++ b/src/core/ikura/shape/bone/stickTetrahedronBone.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "../cube/singleColorCube.hpp"
-#include "./bone.hpp"
+#include "bone.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/cube/cube.cpp
+++ b/src/core/ikura/shape/cube/cube.cpp
@@ -1,7 +1,7 @@
+#include "cube.hpp"
+
 #include <algorithm>
 #include <iostream>
-
-#include "cube.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/cube/cube.hpp
+++ b/src/core/ikura/shape/cube/cube.hpp
@@ -5,7 +5,7 @@
 #include <glm/glm.hpp>
 #include <vulkan/vulkan.h>
 
-#include "../shape.hpp"
+#include "shape/shape.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/cube/gradationColorCube.cpp
+++ b/src/core/ikura/shape/cube/gradationColorCube.cpp
@@ -1,4 +1,4 @@
-#include "./gradationColorCube.hpp"
+#include "gradationColorCube.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/cube/gradationColorCube.hpp
+++ b/src/core/ikura/shape/cube/gradationColorCube.hpp
@@ -3,7 +3,7 @@
 #include <array>
 #include <glm/glm.hpp>
 
-#include "./cube.hpp"
+#include "cube.hpp"
 
 // TODO: init()をなくす
 // SingleColorCube() からは、全て同じ要素のvec3[]をGradationCube()に渡す

--- a/src/core/ikura/shape/cube/separatedColorCube.cpp
+++ b/src/core/ikura/shape/cube/separatedColorCube.cpp
@@ -1,4 +1,4 @@
-#include "./separatedColorCube.hpp"
+#include "separatedColorCube.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/cube/separatedColorCube.hpp
+++ b/src/core/ikura/shape/cube/separatedColorCube.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+
 #include <glm/glm.hpp>
 
 #include "cube.hpp"

--- a/src/core/ikura/shape/cube/separatedColorCube.hpp
+++ b/src/core/ikura/shape/cube/separatedColorCube.hpp
@@ -3,7 +3,7 @@
 #include <array>
 #include <glm/glm.hpp>
 
-#include "./cube.hpp"
+#include "cube.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/cube/singleColorCube.cpp
+++ b/src/core/ikura/shape/cube/singleColorCube.cpp
@@ -1,9 +1,9 @@
+#include "singleColorCube.hpp"
+
 #include <algorithm>
 #include <array>
 
 #include <glm/glm.hpp>
-
-#include "singleColorCube.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/cube/singleColorCube.cpp
+++ b/src/core/ikura/shape/cube/singleColorCube.cpp
@@ -3,7 +3,7 @@
 
 #include <glm/glm.hpp>
 
-#include "./singleColorCube.hpp"
+#include "singleColorCube.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/cube/singleColorCube.hpp
+++ b/src/core/ikura/shape/cube/singleColorCube.hpp
@@ -2,7 +2,7 @@
 
 #include <glm/glm.hpp>
 
-#include "./gradationColorCube.hpp"
+#include "gradationColorCube.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/debug/debugObject.cpp
+++ b/src/core/ikura/shape/debug/debugObject.cpp
@@ -1,4 +1,4 @@
-#include "./debugObject.hpp"
+#include "debugObject.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/debug/debugObject.hpp
+++ b/src/core/ikura/shape/debug/debugObject.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../shape.hpp"
+#include "shape/shape.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/debug/directionDebugObject.cpp
+++ b/src/core/ikura/shape/debug/directionDebugObject.cpp
@@ -1,6 +1,6 @@
 #include <vector>
 
-#include "./directionDebugObject.hpp"
+#include "directionDebugObject.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/debug/directionDebugObject.cpp
+++ b/src/core/ikura/shape/debug/directionDebugObject.cpp
@@ -1,6 +1,6 @@
-#include <vector>
-
 #include "directionDebugObject.hpp"
+
+#include <vector>
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/debug/directionDebugObject.hpp
+++ b/src/core/ikura/shape/debug/directionDebugObject.hpp
@@ -3,7 +3,7 @@
 #include <array>
 #include <memory>
 
-#include "../cube/singleColorCube.hpp"
+#include "shape/cube/singleColorCube.hpp"
 #include "debugObject.hpp"
 
 // TODO: make another abstract class as parent

--- a/src/core/ikura/shape/debug/directionDebugObject.hpp
+++ b/src/core/ikura/shape/debug/directionDebugObject.hpp
@@ -3,8 +3,8 @@
 #include <array>
 #include <memory>
 
-#include "shape/cube/singleColorCube.hpp"
 #include "debugObject.hpp"
+#include "shape/cube/singleColorCube.hpp"
 
 // TODO: make another abstract class as parent
 

--- a/src/core/ikura/shape/debug/directionDebugObject.hpp
+++ b/src/core/ikura/shape/debug/directionDebugObject.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "../cube/singleColorCube.hpp"
-#include "./debugObject.hpp"
+#include "debugObject.hpp"
 
 // TODO: make another abstract class as parent
 

--- a/src/core/ikura/shape/floor/filledFloor.cpp
+++ b/src/core/ikura/shape/floor/filledFloor.cpp
@@ -1,4 +1,4 @@
-#include "./filledFloor.hpp"
+#include "filledFloor.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/floor/filledFloor.hpp
+++ b/src/core/ikura/shape/floor/filledFloor.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "./floor.hpp"
+#include "floor.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/floor/floor.cpp
+++ b/src/core/ikura/shape/floor/floor.cpp
@@ -1,4 +1,4 @@
-#include "./floor.hpp"
+#include "floor.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/floor/floor.hpp
+++ b/src/core/ikura/shape/floor/floor.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../shape.hpp"
+#include "shape/shape.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/floor/gridFloor.cpp
+++ b/src/core/ikura/shape/floor/gridFloor.cpp
@@ -1,4 +1,4 @@
-#include "./gridFloor.hpp"
+#include "gridFloor.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/floor/gridFloor.hpp
+++ b/src/core/ikura/shape/floor/gridFloor.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "./floor.hpp"
+#include "floor.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/shape.cpp
+++ b/src/core/ikura/shape/shape.cpp
@@ -1,6 +1,6 @@
-#include <algorithm>
-
 #include "shape.hpp"
+
+#include <algorithm>
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/shape.cpp
+++ b/src/core/ikura/shape/shape.cpp
@@ -1,6 +1,6 @@
 #include <algorithm>
 
-#include "./shape.hpp"
+#include "shape.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/shape.hpp
+++ b/src/core/ikura/shape/shape.hpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <vector>
 
-#include "../common/renderPrimitiveTypes.hpp"
+#include "common/renderPrimitiveTypes.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/shapes.hpp
+++ b/src/core/ikura/shape/shapes.hpp
@@ -1,21 +1,21 @@
 #pragma once
 
-#include "./shape.hpp"
+#include "shape.hpp"
 
-#include "./debug/directionDebugObject.hpp"
+#include "debug/directionDebugObject.hpp"
 
-#include "./bone/bone.hpp"
-#include "./bone/octahedronBone.hpp"
-#include "./bone/stickTetrahedronBone.hpp"
+#include "bone/bone.hpp"
+#include "bone/octahedronBone.hpp"
+#include "bone/stickTetrahedronBone.hpp"
 
-#include "./sphere/sphere.hpp"
-#include "./sphere/singleColorSphere.hpp"
+#include "sphere/sphere.hpp"
+#include "sphere/singleColorSphere.hpp"
 
-#include "./cube/cube.hpp"
-#include "./cube/gradationColorCube.hpp"
-#include "./cube/separatedColorCube.hpp"
-#include "./cube/singleColorCube.hpp"
+#include "cube/cube.hpp"
+#include "cube/gradationColorCube.hpp"
+#include "cube/separatedColorCube.hpp"
+#include "cube/singleColorCube.hpp"
 
-#include "./floor/filledFloor.hpp"
-#include "./floor/floor.hpp"
-#include "./floor/gridFloor.hpp"
+#include "floor/filledFloor.hpp"
+#include "floor/floor.hpp"
+#include "floor/gridFloor.hpp"

--- a/src/core/ikura/shape/sphere/singleColorSphere.cpp
+++ b/src/core/ikura/shape/sphere/singleColorSphere.cpp
@@ -1,4 +1,4 @@
-#include "./singleColorSphere.hpp"
+#include "singleColorSphere.hpp"
 
 #include <cmath>
 

--- a/src/core/ikura/shape/sphere/singleColorSphere.hpp
+++ b/src/core/ikura/shape/sphere/singleColorSphere.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "./sphere.hpp"
+#include "sphere.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/sphere/sphere.cpp
+++ b/src/core/ikura/shape/sphere/sphere.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <vector>
 
-#include "./sphere.hpp"
+#include "sphere.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/sphere/sphere.cpp
+++ b/src/core/ikura/shape/sphere/sphere.cpp
@@ -1,9 +1,9 @@
+#include "sphere.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <vector>
-
-#include "sphere.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/shape/sphere/sphere.hpp
+++ b/src/core/ikura/shape/sphere/sphere.hpp
@@ -2,7 +2,7 @@
 
 #include <glm/glm.hpp>
 
-#include "../shape.hpp"
+#include "shape/shape.hpp"
 
 namespace ikura {
 namespace shapes {

--- a/src/core/ikura/window/nativeWindow/glfwNativeWindow.cpp
+++ b/src/core/ikura/window/nativeWindow/glfwNativeWindow.cpp
@@ -1,4 +1,4 @@
-#include "./glfwNativeWindow.hpp"
+#include "glfwNativeWindow.hpp"
 
 #include <easylogging++.h>
 

--- a/src/core/ikura/window/nativeWindow/glfwNativeWindow.cpp
+++ b/src/core/ikura/window/nativeWindow/glfwNativeWindow.cpp
@@ -2,9 +2,9 @@
 
 #include <easylogging++.h>
 
-#include "../virtualWindow/virtualWindow.hpp"
+#include "window/virtualWindow/virtualWindow.hpp"
 
-#include "../../common/logLevels.hpp"
+#include "common/logLevels.hpp"
 
 #if defined(IS_WINDOWS)
 #include <climits>

--- a/src/core/ikura/window/nativeWindow/glfwNativeWindow.cpp
+++ b/src/core/ikura/window/nativeWindow/glfwNativeWindow.cpp
@@ -2,9 +2,8 @@
 
 #include <easylogging++.h>
 
-#include "window/virtualWindow/virtualWindow.hpp"
-
 #include "common/logLevels.hpp"
+#include "window/virtualWindow/virtualWindow.hpp"
 
 #if defined(IS_WINDOWS)
 #include <climits>

--- a/src/core/ikura/window/nativeWindow/glfwNativeWindow.hpp
+++ b/src/core/ikura/window/nativeWindow/glfwNativeWindow.hpp
@@ -2,9 +2,8 @@
 
 #include <memory>
 
-#include <vulkan/vulkan.hpp>
-
 #include <GLFW/glfw3.h>
+#include <vulkan/vulkan.hpp>
 
 #include "nativeWindow.hpp"
 

--- a/src/core/ikura/window/nativeWindow/glfwNativeWindow.hpp
+++ b/src/core/ikura/window/nativeWindow/glfwNativeWindow.hpp
@@ -6,7 +6,7 @@
 
 #include <GLFW/glfw3.h>
 
-#include "./nativeWindow.hpp"
+#include "nativeWindow.hpp"
 
 namespace ikura {
 class GlfwNativeWindow : public NativeWindow {

--- a/src/core/ikura/window/nativeWindow/glfwNativeWindow.hpp
+++ b/src/core/ikura/window/nativeWindow/glfwNativeWindow.hpp
@@ -2,6 +2,8 @@
 
 #include <memory>
 
+#define GLFW_INCLUDE_VULKAN
+
 #include <GLFW/glfw3.h>
 #include <vulkan/vulkan.hpp>
 

--- a/src/core/ikura/window/nativeWindow/nativeWindow.cpp
+++ b/src/core/ikura/window/nativeWindow/nativeWindow.cpp
@@ -1,4 +1,4 @@
-#include "./nativeWindow.hpp"
+#include "nativeWindow.hpp"
 
 #include <easylogging++.h>
 #include <vulkan/vulkan.hpp>

--- a/src/core/ikura/window/nativeWindow/nativeWindow.cpp
+++ b/src/core/ikura/window/nativeWindow/nativeWindow.cpp
@@ -3,9 +3,9 @@
 #include <easylogging++.h>
 #include <vulkan/vulkan.hpp>
 
-#include "../virtualWindow/virtualWindow.hpp"
+#include "window/virtualWindow/virtualWindow.hpp"
 
-#include "../../common/logLevels.hpp"
+#include "common/logLevels.hpp"
 
 namespace ikura {
 void NativeWindow::recreateSwapChain(bool destroyExistingResources) {}

--- a/src/core/ikura/window/nativeWindow/nativeWindow.cpp
+++ b/src/core/ikura/window/nativeWindow/nativeWindow.cpp
@@ -3,9 +3,8 @@
 #include <easylogging++.h>
 #include <vulkan/vulkan.hpp>
 
-#include "window/virtualWindow/virtualWindow.hpp"
-
 #include "common/logLevels.hpp"
+#include "window/virtualWindow/virtualWindow.hpp"
 
 namespace ikura {
 void NativeWindow::recreateSwapChain(bool destroyExistingResources) {}

--- a/src/core/ikura/window/nativeWindow/nativeWindow.hpp
+++ b/src/core/ikura/window/nativeWindow/nativeWindow.hpp
@@ -5,8 +5,8 @@
 
 #include <vulkan/vulkan.hpp>
 
-#include "../../engine/renderEngine/renderEngine.hpp"
-#include "../window.hpp"
+#include "engine/renderEngine/renderEngine.hpp"
+#include "window/window.hpp"
 
 namespace ikura {
 class VirtualWindow;

--- a/src/core/ikura/window/virtualWindow/imGuiVirtualWindow.cpp
+++ b/src/core/ikura/window/virtualWindow/imGuiVirtualWindow.cpp
@@ -1,4 +1,4 @@
-#include "./imGuiVirtualWindow.hpp"
+#include "imGuiVirtualWindow.hpp"
 
 #include <filesystem>
 

--- a/src/core/ikura/window/virtualWindow/imGuiVirtualWindow.hpp
+++ b/src/core/ikura/window/virtualWindow/imGuiVirtualWindow.hpp
@@ -3,7 +3,7 @@
 #include <ikura_ext_imgui/imgui.h>
 
 #include "../nativeWindow/glfwNativeWindow.hpp"
-#include "./virtualWindow.hpp"
+#include "virtualWindow.hpp"
 
 namespace ikura {
 struct ImGuiVirtualWindowInitConfig {

--- a/src/core/ikura/window/virtualWindow/imGuiVirtualWindow.hpp
+++ b/src/core/ikura/window/virtualWindow/imGuiVirtualWindow.hpp
@@ -2,8 +2,8 @@
 
 #include <ikura_ext_imgui/imgui.h>
 
-#include "window/nativeWindow/glfwNativeWindow.hpp"
 #include "virtualWindow.hpp"
+#include "window/nativeWindow/glfwNativeWindow.hpp"
 
 namespace ikura {
 struct ImGuiVirtualWindowInitConfig {

--- a/src/core/ikura/window/virtualWindow/imGuiVirtualWindow.hpp
+++ b/src/core/ikura/window/virtualWindow/imGuiVirtualWindow.hpp
@@ -2,7 +2,7 @@
 
 #include <ikura_ext_imgui/imgui.h>
 
-#include "../nativeWindow/glfwNativeWindow.hpp"
+#include "window/nativeWindow/glfwNativeWindow.hpp"
 #include "virtualWindow.hpp"
 
 namespace ikura {

--- a/src/core/ikura/window/virtualWindow/virtualWindow.cpp
+++ b/src/core/ikura/window/virtualWindow/virtualWindow.cpp
@@ -1,4 +1,4 @@
-#include "./virtualWindow.hpp"
+#include "virtualWindow.hpp"
 
 #include <vulkan/vulkan.hpp>
 

--- a/src/core/ikura/window/virtualWindow/virtualWindow.hpp
+++ b/src/core/ikura/window/virtualWindow/virtualWindow.hpp
@@ -2,8 +2,8 @@
 
 #include <memory>
 
-#include "../nativeWindow/nativeWindow.hpp"
-#include "../window.hpp"
+#include "window/nativeWindow/nativeWindow.hpp"
+#include "window/window.hpp"
 
 namespace ikura {
 class VirtualWindow : public Window {

--- a/src/core/ikura/window/window.cpp
+++ b/src/core/ikura/window/window.cpp
@@ -1,4 +1,4 @@
-#include "./window.hpp"
+#include "window.hpp"
 
 #include <easylogging++.h>
 

--- a/src/core/ikura/window/window.hpp
+++ b/src/core/ikura/window/window.hpp
@@ -5,8 +5,8 @@
 
 #include <vulkan/vulkan.hpp>
 
-#include "../renderComponent/renderContent.hpp"
-#include "../renderComponent/renderTarget.hpp"
+#include "renderComponent/renderContent.hpp"
+#include "renderComponent/renderTarget.hpp"
 
 namespace ikura {
 class Window {


### PR DESCRIPTION
[Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) に準拠するようincludeパスをリファクタリングする。

- includeパスで、 `./` や `../` を使わないようにする
    - プロジェクトルートからの相対パスで指定するようにする
- include文を適切にグルーピングし、並び替える
    - 参照: https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes

todo

- [x] src/app側も対応する