### PR TITLE
feat: re-add pull_request event

### DIFF
--- a/.github/workflows/report_clang_tidy.yml
+++ b/.github/workflows/report_clang_tidy.yml
@@ -1,5 +1,6 @@
 name: report-clang-tidy
 on:
+  pull_request:
   workflow_call:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
#69 のやり残し
devがmainにマージされるまでブラウザ上でworkflowを実行できないので、pull_requestイベントを追加しておく